### PR TITLE
Search improvements

### DIFF
--- a/Backend/Monolithic/ContosoMaintenance.WebAPI.csproj
+++ b/Backend/Monolithic/ContosoMaintenance.WebAPI.csproj
@@ -35,10 +35,10 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
         <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.9.1" />
-        <PackageReference Include="Microsoft.Azure.Search" Version="3.0.5" />
         <PackageReference Include="WindowsAzure.Storage" Version="9.1.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="2.3.0" />
+        <PackageReference Include="Microsoft.Azure.Search" Version="5.0.0" />
     </ItemGroup>
     <ItemGroup>
         <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />

--- a/Backend/Monolithic/Controllers/SearchController.cs
+++ b/Backend/Monolithic/Controllers/SearchController.cs
@@ -17,7 +17,7 @@ namespace ContosoMaintenance.WebAPI.Controllers
 
         public SearchController(IConfiguration configuration)
         {
-            serviceClient = new SearchServiceClient(configuration["AzureSearch:AzureSearchServiceName"], new SearchCredentials(configuration["AzureSearch:AzureSearchApiKey"]));
+            serviceClient = new SearchServiceClient(configuration["AzureSearch:ServiceName"], new SearchCredentials(configuration["AzureSearch:ApiKey"]));
         }
 
         /// <summary>
@@ -25,36 +25,51 @@ namespace ContosoMaintenance.WebAPI.Controllers
         /// </summary>
         /// <returns>Result list of Jobs</returns>
         /// <param name="keyword">Search keyword</param>
+        /// <param name="suggestions">Should return suggestions or full search?</param>
         [HttpGet]
         [Route("/api/search/jobs")]
-        public async Task<List<Job>> Get(string keyword)
+        public async Task<List<Job>> Get(string keyword, bool suggestions = false)
         {
-            var sp = new SuggestParameters();
-            sp.HighlightPreTag = "[";
-            sp.HighlightPostTag = "]";
-            sp.UseFuzzyMatching = true;
-            sp.MinimumCoverage = 50;
-            sp.Top = 100;
-
             var indexClient = serviceClient.Indexes.GetClient("job-index");
-
-            var response = await indexClient.Documents.SuggestAsync<Job>(keyword, "suggestions", sp);
-
             var jobList = new List<Job>();
-            foreach (var document in response.Results)
-            {
-                var job = new Job
-                {
-                    Name = document.Text,
-                    Details = document.Document.Details,
-                    Status = document.Document.Status,
-                };
 
-                jobList.Add(job);
+            if(suggestions)
+            {
+                var sp = new SuggestParameters();
+                sp.HighlightPreTag = "[";
+                sp.HighlightPostTag = "]";
+                sp.UseFuzzyMatching = true;
+                sp.MinimumCoverage = 75;
+                sp.Top = 100;
+
+                var response = await indexClient.Documents.SuggestAsync<Job>(keyword, "suggestions", sp);
+
+                foreach (var document in response.Results)
+                {
+                    var job = new Job
+                    {
+                        Name = document.Text,
+                        Details = document.Document.Details,
+                        Status = document.Document.Status,
+                    };
+                    jobList.Add(job);
+                }
+            }
+            else
+            {
+                var sp = new SearchParameters();
+                var response = await indexClient.Documents.SearchAsync<Job>(keyword, sp);
+                foreach (var document in response.Results)
+                {
+                    Job job = new Job
+                    {
+                        Name = document.Document.Name,
+                        Details = document.Document.Details
+                    };
+                    jobList.Add(job);
+                }
             }
             return jobList;
         }
-
-
     }
 }

--- a/Backend/Monolithic/appsettings.json
+++ b/Backend/Monolithic/appsettings.json
@@ -27,8 +27,8 @@
         "DatabaseId": ""
     },
     "AzureSearch": {
-        "AzureSearchServiceName": "",
-        "AzureSearchApiKey": "",
+        "ServiceName": "contosomaintenance",
+        "ApiKey": "5F01767846A092CB8678973CA05D5B60",
     },
     "ActiveDirectory": {
         "Tenant": "",

--- a/Backend/Monolithic/appsettings.json
+++ b/Backend/Monolithic/appsettings.json
@@ -27,8 +27,8 @@
         "DatabaseId": ""
     },
     "AzureSearch": {
-        "ServiceName": "contosomaintenance",
-        "ApiKey": "5F01767846A092CB8678973CA05D5B60",
+        "ServiceName": "",
+        "ApiKey": ""
     },
     "ActiveDirectory": {
         "Tenant": "",

--- a/Mobile/ContosoFieldService.Core/Services/JobsAPIService.cs
+++ b/Mobile/ContosoFieldService.Core/Services/JobsAPIService.cs
@@ -21,8 +21,8 @@ namespace ContosoFieldService.Services
         [Get("/job/{id}/")]
         Task<Job> GetJobById(string id, [Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
 
-        [Get("/jobs?keyword={keyword}")]
-        Task<List<Job>> SearchJobs(string keyword, [Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
+        [Get("/jobs?keyword={keyword}&suggestions={enableSuggestions}")]
+        Task<List<Job>> SearchJobs(string keyword, bool enableSuggestions, [Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
 
         [Post("/job/")]
         Task<Job> CreateJob([Body] Job job, [Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
@@ -109,12 +109,12 @@ namespace ContosoFieldService.Services
             return (ResponseCode.Error, null);
         }
 
-        public async Task<(ResponseCode code, List<Job> result)> SearchJobsAsync(string keyword)
+        public async Task<(ResponseCode code, List<Job> result)> SearchJobsAsync(string keyword, bool enableSuggestions = false)
         {
             // Create an instance of the Refit RestService for the job interface.
             IJobServiceAPI api = RestService.For<IJobServiceAPI>(Constants.BaseUrl);
 
-            var pollyResult = await Policy.ExecuteAndCaptureAsync(async () => await api.SearchJobs(keyword, Constants.ApiManagementKey));
+            var pollyResult = await Policy.ExecuteAndCaptureAsync(async () => await api.SearchJobs(keyword, enableSuggestions, Constants.ApiManagementKey));
             if (pollyResult.Result != null)
             {
                 return (ResponseCode.Success, pollyResult.Result);

--- a/Mobile/ContosoFieldService.Core/Services/JobsAPIService.cs
+++ b/Mobile/ContosoFieldService.Core/Services/JobsAPIService.cs
@@ -21,7 +21,7 @@ namespace ContosoFieldService.Services
         [Get("/job/{id}/")]
         Task<Job> GetJobById(string id, [Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
 
-        [Get("/search/jobs/?keyword={keyword}")]
+        [Get("/jobs?keyword={keyword}")]
         Task<List<Job>> SearchJobs(string keyword, [Header("Ocp-Apim-Subscription-Key")] string apiManagementKey);
 
         [Post("/job/")]

--- a/Mobile/ContosoFieldService.Core/ViewModels/Jobs/JobsViewModel.cs
+++ b/Mobile/ContosoFieldService.Core/ViewModels/Jobs/JobsViewModel.cs
@@ -46,7 +46,7 @@ namespace ContosoFieldService.ViewModels
                     ReloadData(true).GetAwaiter().GetResult();
                 }
                 else
-                    Search.Execute(value);
+                    Suggest.Execute(value);
             }
         }
 
@@ -120,6 +120,38 @@ namespace ContosoFieldService.ViewModels
                 });
             }
         }
+
+        public Command Suggest
+        {
+            get
+            {
+                return new Command(async () =>
+                {
+                    IsRefreshing = true;
+                    IsLoading = true;
+
+                    var response = await jobsApiService.SearchJobsAsync(SearchText, true);
+
+                    // Notify user about errors if applicable
+                    await HandleResponseCodeAsync(response.code);
+
+                    // Handle Response Result
+                    if (response.result != null)
+                    {
+                        Jobs.ReplaceRange(new List<GroupedJobs>
+                        {
+                            new GroupedJobs("Suggestions", response.result)
+                        });
+                    }
+
+                    IsRefreshing = false;
+                    IsLoading = false;
+                });
+            }
+        }
+
+
+
 
         public Command AddJobClicked
         {

--- a/Walkthrough Guide/07 API Management/Assets/Swagger/Search.swagger.json
+++ b/Walkthrough Guide/07 API Management/Assets/Swagger/Search.swagger.json
@@ -34,16 +34,28 @@
         "/jobs": {
             "get": {
                 "operationId": "Search Jobs",
+                "summary": "Search Jobs",
                 "parameters": [
                     {
                         "name": "keyword",
                         "in": "query",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "name": "suggestions",
+                        "in": "query",
+                        "type": "string",
+                        "default": "false",
+                        "enum": [
+                            "false",
+                            "true"
+                        ]
                     }
                 ],
                 "responses": {}
             }
         }
-    }
+    },
+    "tags": []
 }


### PR DESCRIPTION
Fixing search crashing app. 

To resolve this I've reverted back to our previous behaviour of providing only search results by default rather than suggestions. 

We now have the option of adding a query to the URL (on the APIm and Web API) called 'suggestions' and setting this to true. By default in every instance this is set to false (including the view models). 

I've gone ahead and updated that with textchanged events from the searchfield in the UI, we will raise the Suggestions method and only on the Return key being pressed will we execute a full search. 

There is currently a bug with the app incorrectly showing an error popup but when clearing the search text but this beats the app crashing entirely as previously experienced before this PR